### PR TITLE
Add pt-br language support to api

### DIFF
--- a/affirmations.js
+++ b/affirmations.js
@@ -48,4 +48,31 @@ const affirmations = [
   "It's not a mistake, it's a learning opportunity",
 ];
 
-module.exports = affirmations
+// Brazillian affirmations
+const affirmations_ptBr = [
+  "Você consegue",
+  "Você vai dar um jeito",
+  "Eu acredito em você",
+  "Ser horrível em algo é o primeiro passo para se tornar bom naquilo",
+  "Erros não te fazem menos capaz",
+  "Você é um humano capaz",
+  "Você sabe mais do acha",
+  "Se tudo fosse fácil você ficaria entendiado",
+  "Eu te admiro por estar seguindo em frente",
+  "Você vai achar a solução",
+  "Eu sei que você vai conseguir",
+  "Ter dificuldades significa que você está aprendendo",
+  "Você está fazendo um ótimo trabalho",
+  "Estou torcendo por você",
+  "Sua mente é cheia de grandes ideias",
+  "Você faz a diferença no mundo simplesmente por existir nele",
+  "Pessoas com objetivos têm êxito porque eles sabem aonde estão indo",
+  "Tudo que você precisa é de um plano, um caminho, e a coragem para persistir até o seu destino",
+  "O oposto de coragem em nossa sociedade não é covardia... É conformismo",
+  "O caminho para o sucesso é ter atitude",
+  "Um progresso pequeno é ainda assim um progresso",
+  "Começar é o passo mais difícil - mas você consegue",
+  "Não se esqueça de aproveitar a jornada",
+];
+
+module.exports = {affirmations, affirmations_ptBr}

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ const app = express();
 let PORT = process.env.PORT || 3000;
 
 app.get('/', (req, res) => {
-  res.json({affirmation: getRandomAffirmation()});
+  const lang = req.query.lang;
+  res.json({affirmation: getRandomAffirmation(lang)});
 });
 
 const server = app.listen(PORT, () => console.log(`Server is live at localhost:${PORT}`));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "an api for getting affirmations",
   "main": "index.js",
   "scripts": {
-      "test": "jest --coverage --forceExit",
+    "test": "jest --coverage --forceExit",
     "start": "node index.js",
     "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'"
   },

--- a/random_affirmation.js
+++ b/random_affirmation.js
@@ -1,4 +1,19 @@
-const affirmations = require('./affirmations')
+const {
+  affirmations, 
+  affirmations_ptBr,
+} = require('./affirmations')
 
-const getRandomAffirmation = () => affirmations[Math.floor(Math.random() * affirmations.length)];
+const getRandomAffirmation = (lang='en-us') => {
+  let affimationsList = [];
+
+  // If the lang is set to pt-br then use the Brazillian affirmations list
+  // the default lang is en-us
+  if (lang==='pt-br')
+    affimationsList = affirmations_ptBr; 
+  else 
+    affimationsList = affirmations; 
+  
+  return affimationsList[Math.floor(Math.random() * affimationsList.length)];
+};
+
 module.exports = getRandomAffirmation;


### PR DESCRIPTION
The API works like the same as before, all I've done was creating a new affirmations list in pt-BR and made it possible to use a `lang` query that defaults to us-en, but when pt-br is passed the API will return an affirmation from the pt-BR list.